### PR TITLE
Show symbols which are acceptable in the state when emitting a syntax error

### DIFF
--- a/pyLRp/__main__.py
+++ b/pyLRp/__main__.py
@@ -211,6 +211,8 @@ if syn.grammar.start_symbol is not None:
     if args.print_parsetable:
         parse_table.print()
 
+    next_table = graph.create_next_table()
+
     del graph
 else:
     # generate the tokens required by the parser
@@ -248,7 +250,7 @@ try:
                         debug=args.debug,
                         python3=args.python3)
 
-        writer.write(syn, parse_table, lexer)
+        writer.write(syn, parse_table, lexer, next_table)
 
         if logger.loggedErrors():
             print("error: ", e, file=sys.stderr)

--- a/pyLRp/lr.py
+++ b/pyLRp/lr.py
@@ -623,8 +623,8 @@ class LR1StateTransitionGraph(StateTransitionGraph):
 
     def construct(self):
 
-        prod = Production(self.grammar.define_meta("$START"),
-                          [self.grammar.start_symbol], -1)
+        prod = Production(self.grammar.symtable.define_meta("$START"),
+                          [self.grammar.grammar.start_symbol], -1)
         prod.action = PyText("raise Accept()")
 
         self.grammar.symtable.define_meta("$START").add_prod(prod)

--- a/pyLRp/parsers/pyLRparser.pyLRp
+++ b/pyLRp/parsers/pyLRparser.pyLRp
@@ -741,10 +741,10 @@ def add_error(self, prod, pos):
 
 def check_for_undefined_metas(parser):
     for symbol, posis in sorted(parser.syntax.symtable.undef(),
-                                key=lambda x: x[0].name):
+                                key=lambda x: x[0]):
         for pos in posis:
             error(parser, pos,
-                  "used undefined symbol {}".format(symbol.name))
+                  "used undefined symbol {}".format(symbol))
 
 class PyBlobBuilder(object):
     def __init__(self):

--- a/pyLRp/parsers/pyLRparser.pyLRp
+++ b/pyLRp/parsers/pyLRparser.pyLRp
@@ -171,6 +171,7 @@ from ..pyblob import PyBlobVisitor, PySuite, PyText, PyNewline, PyStackvar
 <PARSERULE>\]        CBRACKET
 <PARSERULE>{space}+  %restart
 <PARSERULE>\\\n      %restart
+<PARSERULE>{comment}\n %push(PARSERULE), %push(INDENT), NEWLINE
 <PARSERULE>\n        %push(PARSERULE), %push(INDENT), NEWLINE
 <PARSERULE>:         %push(PYINLINE), COLON
 

--- a/pyLRp/writers/pywriter.py
+++ b/pyLRp/writers/pywriter.py
@@ -637,7 +637,12 @@ class SyntaxError(Exception):
 
 # default definitions of the error reporting functions there are
 # usually overwritten by the parser
-def error(parser, pos, msg):
+def error(parser, pos, msg, next_symbols):
+    if next_symbols:
+        msg = "{}: expected one of: {}".format(
+            msg,
+            ", ".join(name for _, name in next_symbols),
+        )
     raise SyntaxError(message=msg, position=pos)
 
 def warning(parser, pos, msg):
@@ -768,15 +773,10 @@ class Parser(object):
                         recovering = True
                         rec = """ + str(symtable["$RECOVER"].number) + r"""
 
-                        error(self, pos, "syntax error: expected one of: {}".format(
-                            ", ".join(
-                                name
-                                for _, name in self.solve_for_next_symbols(
-                                    tuple(entry.state for entry in self.stack),
-                                    seen=set()
-                                )
-                            )
-                        ))
+                        error(self, pos, "syntax error", self.solve_for_next_symbols(
+                            tuple(entry.state for entry in self.stack),
+                            seen=set())
+                        )
 
                         # pop tokens until error can be shifted
                         t, d = atable[stack[-1].state][rec]

--- a/pyLRp/writers/pywriter.py
+++ b/pyLRp/writers/pywriter.py
@@ -708,8 +708,13 @@ class Parser(object):
 
                 else: # t == 2
                     if recovering:
-                        # just skip unfit tokens during recovery
-                        pass
+                        # just skip unfit tokens during recovery, but error on
+                        # $EOF to prevent a loop
+                        if token == """ + str(symtable["$EOF"].number) + r""":
+                            raise SyntaxError(
+                                "Reached EOF during error recovery!",
+                                position=pos
+                            )
                     else:
                         # setup error recovery by shifting the $RECOVER token
                         recovering = True


### PR DESCRIPTION
example grammar:

```
%lexer

%def
    space [\ \t\n]

{space}+  %restart
\+        OP_PLUS
\*        OP_STAR
/         OP_SLASH
-         OP_MINUS
\(        PAREN_OPEN
\)        PAREN_CLOSE
[0-9]+    INTEGER

%parser

%left OP_PLUS OP_MINUS
%left OP_SLASH OP_STAR

expression:
  value:
    $$.sem = $1.sem
  expression OP_PLUS value:
    $$.sem = ('+', $1.sem, $3.sem, $$.pos)
  expression OP_STAR value:
    $$.sem = ('*', $1.sem, $3.sem, $$.pos)
  expression OP_MINUS value:
    $$.sem = ('-', $1.sem, $3.sem, $$.pos)
  expression OP_SLASH value:
    $$.sem = ('/', $1.sem, $3.sem, $$.pos)

value:
  INTEGER:
    $$.sem = ('int', int($1.sem), $1.pos)
  PAREN_OPEN expression PAREN_CLOSE:
    $$.sem = $2.sem
```

Example output (for input ``1+``):
```
0 # (0, 4) INTEGER "1"
0 4 # (1, 5) OP_PLUS "+"
0 6 # (1, 0) OP_PLUS "+"
0 1 # (0, 2) OP_PLUS "+"
0 1 2 # (2, 0) $EOF ""
Traceback (most recent call last):
  File "testparser.py", line 31, in <module>
    ast = parser.Parse()
  File "parser.py", line 324, in Parse
    for _, name in self.ntable[self.stack[-1].state]
  File "parser.py", line 228, in error
    raise SyntaxError(message=msg, position=pos)
<run_path>.SyntaxError: test.input Line 2:0 - 2:0:syntax error: expected one of: value
```

Example output (for input ``(2``):
```
0 # (0, 5) PAREN_OPEN "("
0 5 # (0, 4) INTEGER "2"
0 5 4 # (1, 5) $EOF ""
0 5 6 # (1, 0) $EOF ""
0 5 7 # (2, 0) $EOF ""
Traceback (most recent call last):
  File "testparser.py", line 31, in <module>
    ast = parser.Parse()
  File "parser.py", line 324, in Parse
    for _, name in self.ntable[self.stack[-1].state]
  File "parser.py", line 228, in error
    raise SyntaxError(message=msg, position=pos)
<run_path>.SyntaxError: test.input Line 1:0 - 1:0:syntax error: expected one of: OP_SLASH, PAREN_CLOSE, OP_STAR, OP_PLUS, OP_MINUS
```